### PR TITLE
Add Task to main 'celery' package re-exports

### DIFF
--- a/celery-stubs/__init__.pyi
+++ b/celery-stubs/__init__.pyi
@@ -2,6 +2,7 @@ from celery._state import current_app as current_app, current_task as current_ta
 from celery.app import shared_task as shared_task
 from celery.app.base import Celery as Celery
 from celery.app.utils import bugreport as bugreport
+from celery.app.task import Task as Task
 from celery.canvas import chain as chain, chord as chord, chunks as chunks, group as group, maybe_signature as maybe_signature, signature as signature, xmap as xmap, xstarmap as xstarmap
 from celery.utils import uuid as uuid
 from collections import namedtuple


### PR DESCRIPTION
Celery documentation has many examples using `from celery import Task`
but this was not recognized by celery-stubs.

E.g.: https://docs.celeryproject.org/en/latest/userguide/tasks.html#instantiation